### PR TITLE
Switch to bundle directories

### DIFF
--- a/src/bundle.js
+++ b/src/bundle.js
@@ -1,27 +1,18 @@
 const path = require('path');
 const exec = require('@actions/exec');
 const github = require('@actions/github');
-
-async function copyArtifacts(artifacts, from, to) {
-    for(const [name, relativePath] of Object.entries(artifacts)) {
-        const fromPath = path.join(from, relativePath);
-        const toPath = path.join(to, name);
-        await exec.exec(`cp -r ${fromPath} ${toPath}`);
-    }
-}
-
-async function bundleArtifacts(artifacts, dir) {
-    const bundleName = github.context.sha;
-    const bundleFileName = bundleName + '.tar.gz';
-    const bundlePath = path.join(dir, bundleFileName);
-    const filesString = Object.keys(artifacts).join(' ');
-
-    await exec.exec(`tar -cvzf ${bundlePath} -C ${dir} ${filesString}`);
-
-    return { bundlePath, bundleFile: bundleFileName, bundleName };
-}
+const fs = require('fs');
 
 module.exports = async function(artifacts, from, to) {
-    await copyArtifacts(artifacts, from, to);
-    return await bundleArtifacts(artifacts, to);
+    const bundleName = github.context.sha;
+    const bundlePath = path.join(to, bundleName);
+    fs.mkdirSync(bundlePath);
+
+    for(const [name, relativePath] of Object.entries(artifacts)) {
+        const fromPath = path.join(from, relativePath);
+        const toPath = path.join(bundlePath, name);
+        await exec.exec(`cp -r ${fromPath} ${toPath}`);
+    }
+
+    return { bundlePath, bundleName };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -9,14 +9,14 @@ const deploy = require('./deploy');
 
 async function main() {
     try {
-        const { tempDir, archivingDir } = setupDirs();
+        const { tempDir } = setupDirs();
         const appDir = process.cwd();
 
         const artifacts = inputs.artifacts;
-        const { bundlePath, bundleFile, bundleName } = await bundleArtifacts(artifacts, appDir, archivingDir);
+        const { bundlePath, bundleName } = await bundleArtifacts(artifacts, appDir, tempDir);
 
         const keyFile = createKeyFile(tempDir);
-        await sendBundle(bundlePath, bundleFile, keyFile);
+        await sendBundle(bundlePath, bundleName, keyFile);
 
         deploy(bundleName);
     }

--- a/src/send.js
+++ b/src/send.js
@@ -2,10 +2,10 @@ const exec = require('@actions/exec');
 const path = require('path');
 const inputs = require('./inputs');
 
-module.exports = async function(bundlePath, bundleFile, keyFile) {
+module.exports = async function(bundlePath, bundleName, keyFile) {
     const host = inputs.host;
     const destinationDir = inputs.destinationDir;
-    const destinationPath = path.join(destinationDir, bundleFile);
+    const destinationPath = path.join(destinationDir, bundleName);
 
-    await exec.exec(`scp -i ${keyFile} -o StrictHostKeyChecking=no ${bundlePath} ${host}:${destinationPath}`);
+    await exec.exec(`scp -r -i ${keyFile} -o StrictHostKeyChecking=no ${bundlePath} ${host}:${destinationPath}`);
 };

--- a/src/setup.js
+++ b/src/setup.js
@@ -4,14 +4,12 @@ const inputs = require('./inputs');
 
 module.exports = function() {
     const tempDir = inputs.tempDir;
-    const archivingDir = path.join(tempDir, 'archiving');
 
     if(fs.existsSync(tempDir)) {
         throw 'Deployer directory already exists!';
     }
 
     fs.mkdirSync(tempDir);
-    fs.mkdirSync(archivingDir);
 
-    return { tempDir, archivingDir };
+    return { tempDir };
 };


### PR DESCRIPTION
Send bundles as directories, rather than .tar.gz files to the server. This is to match the new behavior in the main `deployer` package.