### PR TITLE
Ensure bundles directory exists

### DIFF
--- a/src/send.js
+++ b/src/send.js
@@ -8,7 +8,7 @@ module.exports = async function(bundlePath, bundleName, keyFile) {
     const destinationPath = path.join(destinationDir, bundleName);
 
     // Try to ensure that the destination directory exists.
-    await exec.exec(`ssh -T -i ${keyFile} "mkdir -p ${destinationDir}`);
+    await exec.exec(`ssh -T -i ${keyFile} -p StrictHostKeyChecking=no ${host} "mkdir -p ${destinationDir}`);
 
     // Send the bundle.
     await exec.exec(`scp -r -i ${keyFile} -o StrictHostKeyChecking=no ${bundlePath} ${host}:${destinationPath}`);

--- a/src/send.js
+++ b/src/send.js
@@ -8,7 +8,7 @@ module.exports = async function(bundlePath, bundleName, keyFile) {
     const destinationPath = path.join(destinationDir, bundleName);
 
     // Try to ensure that the destination directory exists.
-    await exec.exec(`ssh -i ${keyFile} "mkdir -p ${destinationDir}`);
+    await exec.exec(`ssh -T -i ${keyFile} "mkdir -p ${destinationDir}`);
 
     // Send the bundle.
     await exec.exec(`scp -r -i ${keyFile} -o StrictHostKeyChecking=no ${bundlePath} ${host}:${destinationPath}`);

--- a/src/send.js
+++ b/src/send.js
@@ -8,7 +8,7 @@ module.exports = async function(bundlePath, bundleName, keyFile) {
     const destinationPath = path.join(destinationDir, bundleName);
 
     // Try to ensure that the destination directory exists.
-    await exec.exec(`ssh -T -i ${keyFile} -p StrictHostKeyChecking=no ${host} "mkdir -p ${destinationDir}`);
+    await exec.exec(`ssh -T -i ${keyFile} -o StrictHostKeyChecking=no ${host} "mkdir -p ${destinationDir}`);
 
     // Send the bundle.
     await exec.exec(`scp -r -i ${keyFile} -o StrictHostKeyChecking=no ${bundlePath} ${host}:${destinationPath}`);

--- a/src/send.js
+++ b/src/send.js
@@ -7,5 +7,9 @@ module.exports = async function(bundlePath, bundleName, keyFile) {
     const destinationDir = inputs.destinationDir;
     const destinationPath = path.join(destinationDir, bundleName);
 
+    // Try to ensure that the destination directory exists.
+    await exec.exec(`ssh -i ${keyFile} "mkdir -p ${destinationDir}`);
+
+    // Send the bundle.
     await exec.exec(`scp -r -i ${keyFile} -o StrictHostKeyChecking=no ${bundlePath} ${host}:${destinationPath}`);
 };


### PR DESCRIPTION
This fixes #7 by running a `mkdir -p` command on the server to ensure that the bundles directory exists before pushing the bundle.