### PR TITLE
Stop sending bundle query parameter

### DIFF
--- a/src/deploy.js
+++ b/src/deploy.js
@@ -1,9 +1,9 @@
 const https = require('https');
 const inputs = module.require('./inputs');
 
-module.exports = function(bundleName) {
+module.exports = function() {
     const deployUrl = inputs.deployUrl;
     if(deployUrl) {
-        https.get(deployUrl + `&bundle=${bundleName}`);
+        https.get(deployUrl);
     }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ async function main() {
         const keyFile = createKeyFile(tempDir);
         await sendBundle(bundlePath, bundleName, keyFile);
 
-        deploy(bundleName);
+        deploy();
     }
     catch (error) {
         core.error(error);

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ async function main() {
         await sendBundle(bundlePath, bundleName, keyFile);
 
         deploy();
+
+        core.setOutput('bundle_name', bundleName);
     }
     catch (error) {
         core.error(error);


### PR DESCRIPTION
Now that deployer v0.4.0 supports simply deploying the latest artifact bundle, this functionality is unnecessary.