### PR TITLE
Destroy key when finished

### DIFF
--- a/src/destroy_key.js
+++ b/src/destroy_key.js
@@ -1,0 +1,7 @@
+const path = require('path');
+const fs = require('fs');
+
+module.exports = function(dir) {
+    const keyFile = path.join(dir, 'id_rsa');
+    fs.rmSync(keyFile);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const inputs = require('./inputs');
 const setupDirs = require('./setup');
 const bundleArtifacts = require('./bundle');
 const createKeyFile = require('./create_key');
+const destroyKeyFile = require('./destroy_key');
 const sendBundle = require('./send');
 const deploy = require('./deploy');
 
@@ -17,6 +18,7 @@ async function main() {
 
         const keyFile = createKeyFile(tempDir);
         await sendBundle(bundlePath, bundleName, keyFile);
+        destroyKeyFile(tempDir);
 
         deploy();
 


### PR DESCRIPTION
After we're finished using the SSH key file to send the bundle, delete
it for security reasons. Resolves #13.
